### PR TITLE
fixed service ticket route for Rals 2.x line

### DIFF
--- a/lib/devise_cas_authenticatable/routes.rb
+++ b/lib/devise_cas_authenticatable/routes.rb
@@ -24,7 +24,7 @@ else
     
     def cas_authenticatable(routes, mapping)
       routes.with_options(:controller => 'devise/cas_sessions', :name_prefix => nil) do |session|
-        session.send(:"#{mapping.name}_service", '/', :action => 'service', :conditions => {:method => :get})
+        session.send(:"#{mapping.name}_service", '/service', :action => 'service', :conditions => {:method => :get})
         session.send(:"unregistered_#{mapping.name}_session", '/unregistered', :action => "unregistered", :conditions => {:method => :get})
         session.send(:"new_#{mapping.name}_session", mapping.path_names[:sign_in], :action => 'new', :conditions => {:method => :get})
         session.send(:"#{mapping.name}_session", mapping.path_names[:sign_in], :action => 'create', :conditions => {:method => :post})


### PR DESCRIPTION
Signed-off-by: Akash Manohar J akash@akash.im

The route for the service ticket was specified as "/" instead of "/service" for Rails 2.x apps. Fixed it.
