### PR TITLE
Destination URL also passed as Follow URL to RubyCAS-Client logout_url.

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -32,7 +32,8 @@ class Devise::CasSessionsController < Devise::SessionsController
     destination << request.host
     destination << ":#{request.port.to_s}" unless request.port == 80
     destination << after_sign_out_path_for(resource_name)
-    redirect_to(::Devise.cas_client.logout_url(destination))
+    follow_url = destination
+    redirect_to(::Devise.cas_client.logout_url(destination, follow_url))
   end
 
   def single_sign_out


### PR DESCRIPTION
As part of issue 30 resolution if you agree. Also didn't realise this would create a new issue. Sorry.
