### PR TITLE
Destination, follow URL and which to pass configurable.

### DIFF
--- a/lib/devise_cas_authenticatable.rb
+++ b/lib/devise_cas_authenticatable.rb
@@ -42,6 +42,15 @@ module Devise
   # The login URL of the CAS server.  If undefined, will default based on cas_base_url.
   @@cas_validate_url = nil
 
+  # The destination url for logout.
+  @@cas_destination_url = nil
+
+  # The follow url for logout.
+  @@cas_follow_url = nil
+
+  # Which url to send with logout, destination or follow. Can either be nil, destination or follow.
+  @@cas_logout_url_param = nil
+
   # Should devise_cas_authenticatable enable single-sign-out? Requires use of a supported
   # session_store. Currently supports active_record or redis.
   # False by default.
@@ -61,8 +70,8 @@ module Devise
 
   # Name of the parameter passed in the logout query 
   @@cas_destination_logout_param_name = nil
-  
-  mattr_accessor :cas_base_url, :cas_login_url, :cas_logout_url, :cas_validate_url, :cas_create_user, :cas_destination_logout_param_name, :cas_username_column, :cas_enable_single_sign_out, :cas_single_sign_out_mapping_strategy
+
+  mattr_accessor :cas_base_url, :cas_login_url, :cas_logout_url, :cas_validate_url, :cas_destination_url, :cas_follow_url, :cas_logout_url_param, :cas_create_user, :cas_destination_logout_param_name, :cas_username_column, :cas_enable_single_sign_out, :cas_single_sign_out_mapping_strategy
 
   def self.cas_create_user?
     cas_create_user


### PR DESCRIPTION
Just a final fix to all of the issues I had raised. This makes everything configurable so compatibility is maximised. You might like to solve it another way.

If cas_destination_url or cas_follow_url is blank and you have set either of those as the logout param, it will create them the way you automatically do now.

Perhaps follow should be called url as that is what it is called in the cas spec but rubycas-client calls it follow so I kept it as follow.

  config.cas_destination_url = 'http://something.com'
  config.cas_follow_url = http://something.com'
  config.cas_logout_url_param = 'destination' //or 'follow' or ''

Just passing this commit on as I needed it more configurable for my needs and thought it would be useful for everyone.
