### PR TITLE
Redirects all requests to new to cas server.

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -2,9 +2,7 @@ class Devise::CasSessionsController < Devise::SessionsController
   unloadable
   
   def new
-    unless returning_from_cas?
-      redirect_to(cas_login_url)
-    end
+    redirect_to(cas_login_url)
   end
   
   def service


### PR DESCRIPTION
If the user tries to logout when not logged in, RubyCAS server will eventually be redirected back to new and the new page will be displayed. I cannot understand why this behaviour would be desirable. Redirecting back to RubyCAS to login is what I would expect. Removing the if solves this.

Was it in there for a very good reason I can't see?
