### PR TITLE
It should not break if ActiveRecord isn't defined

### DIFF
--- a/lib/devise_cas_authenticatable.rb
+++ b/lib/devise_cas_authenticatable.rb
@@ -7,7 +7,7 @@ require 'devise_cas_authenticatable/exceptions'
 
 require 'devise_cas_authenticatable/single_sign_out'
 
-if defined?(ActiveRecord::SessionStore)
+if defined?(ActiveRecord) && defined?(ActiveRecord::SessionStore)
   require 'devise_cas_authenticatable/single_sign_out/session_store/active_record'
 end
 


### PR DESCRIPTION
Hi,

I am using devise_cas_authenticatable with mongoid and it is raising error cause ActiveRecord isn't defined.

Please pull from my repository.

Thanks!
