### PR TITLE
Double slash in service url

### DIFF
--- a/lib/devise_cas_authenticatable.rb
+++ b/lib/devise_cas_authenticatable.rb
@@ -114,7 +114,7 @@ module Devise
         mapping.raw_path
       end
     end
-    u.path << "/"
+    u.path << "/" unless u.path =~ /\/$/
     u.path << action
     u.to_s
   end


### PR DESCRIPTION
The generated service url includes two slashes (like http://example.org//service). This brokes my customization of the rails-rubycas-server. The patch fixes that behavior.

Best regards

Maik Arnold
