### PR TITLE
Resolve issue #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ to tell your app how to talk to your CAS server:
       # config.cas_destination_url = 'https://cas.myorganization.com'
       # config.cas_follow_url = 'https://cas.myorganization.com'
       # config.cas_logout_url_param = nil
-
+      
+      # you can force the CAS to generate service url with 'https' scheme (default is false)
+      # config.cas_force_ssl_service = true
+      
       # By default, devise_cas_authenticatable will create users.  If you would rather
       # require user records to already exist locally before they can authenticate via
       # CAS, uncomment the following line.

--- a/lib/devise_cas_authenticatable.rb
+++ b/lib/devise_cas_authenticatable.rb
@@ -70,9 +70,13 @@ module Devise
 
   # Name of the parameter passed in the logout query 
   @@cas_destination_logout_param_name = nil
+  
+  # Force the https scheme on service url
+  @@cas_force_ssl_service = false
 
   mattr_accessor :cas_base_url, :cas_login_url, :cas_logout_url, :cas_validate_url, :cas_destination_url, :cas_follow_url, :cas_logout_url_param, :cas_create_user, :cas_destination_logout_param_name, :cas_username_column, :cas_enable_single_sign_out, :cas_single_sign_out_mapping_strategy
-
+  mattr_accessor :cas_force_ssl_service
+  
   def self.cas_create_user?
     cas_create_user
   end
@@ -100,6 +104,7 @@ module Devise
   private
   def self.cas_action_url(base_url, mapping, action)
     u = URI.parse(base_url)
+    u.scheme = (@@cas_force_ssl_service ? "https" : "http")
     u.query = nil
     u.path = if mapping.respond_to?(:fullpath)
       if ENV['RAILS_RELATIVE_URL_ROOT']


### PR DESCRIPTION
Hi,
here there are my changes to force the gem to generate a service url with a https scheme.

You will obtain
    https://localhost/cas/login?service=https%3A%2F%2Flocalhost%2Fusers%2Fservice
in place of
    https://localhost/cas/login?service=http%3A%2F%2Flocalhost%2Fusers%2Fservice

when set 
    Devise.setup do |config|
        config.cas_force_ssl_service = true
    end
