### PR TITLE
Added :cas_create_user? method override in  devise resource model

### DIFF
--- a/lib/devise_cas_authenticatable/model.rb
+++ b/lib/devise_cas_authenticatable/model.rb
@@ -27,7 +27,7 @@ module Devise
               find(:first, :conditions => conditions)
             end
             
-            resource = new(conditions) if (resource.nil? and ::Devise.cas_create_user?)
+            resource = new(conditions) if (resource.nil? and ( resource.respond_to? :cas_create_user? ? resource.cas_create_user? : ::Devise.cas_create_user? ) )
             return nil unless resource
             
             if resource.respond_to? :cas_extra_attributes=


### PR DESCRIPTION
The :cas_create_user? method when defined in a resource model will now override the value set in the initializer.
