### PR TITLE
argument for after_sign_in_path_for should be resource

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -8,8 +8,7 @@ class Devise::CasSessionsController < Devise::SessionsController
   end
   
   def service
-    warden.authenticate!(:scope => resource_name)
-    redirect_to after_sign_in_path_for(resource)
+    redirect_to after_sign_in_path_for(warden.authenticate!(:scope => resource_name))
   end
   
   def unregistered


### PR DESCRIPTION
warden.authenticate! should return the user object, and should be passed to the after_sign_in_path_for method (instead of resource_name which would be a symbol)
