### PR TITLE
Resolve sign out then immediately sign back in bug

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -113,11 +113,6 @@ class Devise::CasSessionsController < Devise::SessionsController
   def returning_from_cas?
     params[:ticket] || request.referer =~ /^#{::Devise.cas_client.cas_base_url}/ || request.referer =~ /^#{url_for :action => "service"}/
   end
-  
-  def cas_logout_url
-    ::Devise.cas_client.add_service_to_login_url(::Devise.cas_service_url(request.url, devise_mapping))
-  end
-  helper_method :cas_login_url
 
   def cas_login_url
     ::Devise.cas_client.add_service_to_login_url(::Devise.cas_service_url(request.url, devise_mapping))


### PR DESCRIPTION
...ed because currently on logout the service is blank, therefore, after logout the user will not be able to log back in
