### PR TITLE
Remove unloadable if Rails version >= 4

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -1,6 +1,9 @@
-class Devise::CasSessionsController < Devise::SessionsController  
+class Devise::CasSessionsController < Devise::SessionsController
   include DeviseCasAuthenticatable::SingleSignOut::DestroySession
-  unloadable
+
+  unless Rails.version =~/^4/
+    unloadable
+  end
 
   skip_before_filter :verify_authenticity_token, :only => [:single_sign_out]
 


### PR DESCRIPTION
In Rails 4 "unloadable" give a circular dependency error that prevented the logout.

The change done is the same done in this gem:
https://github.com/DanKnox/websocket-rails/issues/101
