### PR TITLE
Update to use ActionDispatcher::Routing to fix Rails 4 deprecation warnings

### DIFF
--- a/lib/devise_cas_authenticatable/routes.rb
+++ b/lib/devise_cas_authenticatable/routes.rb
@@ -1,5 +1,5 @@
-if ActionController::Routing.name =~ /ActionDispatch/
-  # Rails 3
+if defined? ActionDispatch::Routing
+  # Rails 3, 4
   
   ActionDispatch::Routing::Mapper.class_eval do
     protected


### PR DESCRIPTION
Rails 4 has deprecation warnings when using the `ActionController::Routing` const, this change is equivalent functionality
