### PR TITLE
redirect to cas logout_url for warden_message :inactive

### DIFF
--- a/lib/devise_cas_authenticatable/single_sign_out/warden_failure_app.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out/warden_failure_app.rb
@@ -25,8 +25,8 @@ class DeviseCasAuthenticatable::SingleSignOut::WardenFailureApp < Devise::Failur
   protected
 
   def redirect_url
-    if warden_message == :timeout
-      flash[:timedout] = true
+    if [:timeout, :inactive].include? warden_message
+      flash[:timedout] = true if warden_message == :timeout
       Devise.cas_client.logout_url
     else
       if respond_to?(:scope_path)

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -27,7 +27,7 @@ describe Devise::Strategies::CasAuthenticatable, :type => "acceptance" do
   end
   
   def cas_logout_url
-    @cas_logout_url ||= Devise.cas_base_url + "/logout"
+    @cas_logout_url ||= Devise.cas_base_url + "/logout?service"
   end
   
   def sign_into_cas(username, password)
@@ -75,7 +75,7 @@ describe Devise::Strategies::CasAuthenticatable, :type => "acceptance" do
 
     it "should fail to sign in" do
       sign_into_cas "joeuser", "joepassword"
-      current_url.should == new_user_session_url
+      current_url.should == cas_logout_url
     end
   end
   

--- a/spec/warden_failure_app_spec.rb
+++ b/spec/warden_failure_app_spec.rb
@@ -22,6 +22,18 @@ describe DeviseCasAuthenticatable::SingleSignOut::WardenFailureApp do
 
       end
 
+      describe "resulting from an inactive" do
+
+        before do
+          @failure_app.stubs(:warden_message).returns(:inactive)
+        end
+
+        it "returns the logout url" do
+          @failure_app.send(:redirect_url).should match(/#{cas_logout_url}/)
+        end
+
+      end
+
       describe "resulting from a generic warden :throw error" do
 
         before do


### PR DESCRIPTION
I added the check for an :inactive warden_message and added a spec for that case.

This change affected the spec for failing to sign in with a deactivated user (in strategy_spec.rb).

I update cas_logout_url to include "?service" querystring because rubycas-client's logout_url method returns with that even if no service_url parameter is passed.

Let me know if I should approach it differently. Thanks!
