### PR TITLE
ALWAYS redirect back to CAS server in the event a user attemps to target...

### DIFF
--- a/Gemfile.devise21
+++ b/Gemfile.devise21
@@ -8,4 +8,5 @@ gem 'devise', '~> 2.1.0'
 
 group :test do
   gem 'castronaut', :git => 'https://github.com/nbudin/castronaut.git', :branch => 'dam5s-merge'
+  gem "debugger"
 end

--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -8,9 +8,7 @@ class Devise::CasSessionsController < Devise::SessionsController
   skip_before_filter :verify_authenticity_token, :only => [:single_sign_out]
 
   def new
-    unless returning_from_cas?
-      redirect_to(cas_login_url)
-    end
+    redirect_to(cas_login_url)
   end
 
   def service
@@ -70,10 +68,6 @@ class Devise::CasSessionsController < Devise::SessionsController
       logger.debug "Destroyed session #{session_id} corresponding to service ticket #{session_index}."
     end
     ::DeviseCasAuthenticatable::SingleSignOut::Strategies.current_strategy.delete_session_index(session_index)
-  end
-
-  def returning_from_cas?
-    params[:ticket] || request.referer =~ /^#{::Devise.cas_client.cas_base_url}/ || request.referer =~ /^#{url_for :action => "service"}/
   end
 
   def cas_login_url

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -124,8 +124,6 @@ describe Devise::Strategies::CasAuthenticatable, :type => "acceptance" do
     User.find_by_username("newuser").should be_nil
 
     click_on "sign in using a different account"
-    click_on "here"
-    current_url.should == cas_login_url
     fill_in "Username", :with => "joeuser"
     fill_in "Password", :with => "joepassword"
     click_on "Login"


### PR DESCRIPTION
... an application and is not authorized. It was interesting that even the tests had an unnessecary step of clicking the 'here' link in the default device templates to get around this problem. In the event there is a infinite redirect loop, this needs terminated on the cas server and not the cas client.
