### PR TITLE
Stop filling my log

### DIFF
--- a/lib/devise_cas_authenticatable/single_sign_out.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out.rb
@@ -33,7 +33,7 @@ module DeviseCasAuthenticatable
       end
 
       def destroy_session_by_id(sid)
-        logger.debug "Single Sign Out from session store: #{current_session_store.inspect}"
+        logger.debug "Single Sign Out from session store: #{current_session_store.class}"
 
         if session_store_class.name =~ /ActiveRecord::SessionStore/
           session = session_store_class::Session.find_by_session_id(sid)


### PR DESCRIPTION
It's horrible that `current_session_store.inspect` will return the whole rails configures (when I use cache_store).
