### PR TITLE
Eliminate need to set secret_key in production

### DIFF
--- a/lib/devise_cas_authenticatable/routes.rb
+++ b/lib/devise_cas_authenticatable/routes.rb
@@ -18,6 +18,10 @@ if defined? ActionDispatch::Routing
         match :destroy, :path => mapping.path_names[:sign_out], :as => "destroy", :via => sign_out_via
       end      
     end
+
+    def raise_no_secret_key #:nodoc:
+      # Devise_cas_authenticatable does not store passwords, so does not need a secret!
+    end
   end
 else
   # Rails 2

--- a/lib/devise_cas_authenticatable/routes.rb
+++ b/lib/devise_cas_authenticatable/routes.rb
@@ -21,6 +21,18 @@ if defined? ActionDispatch::Routing
 
     def raise_no_secret_key #:nodoc:
       # Devise_cas_authenticatable does not store passwords, so does not need a secret!
+      logger.warn <<-WARNING
+      Devise_cas_authenticatable has suppressed an exception from being raised for missing Devise.secret_key.
+      If devise_cas_authenticatable is the only devise module you are using for authentication you can safely ignore this warning.
+      However, if you use another module that requires the secret_key please follow these instructions from Devise:
+
+      Devise.secret_key was not set. Please add the following to your Devise initializer:
+  
+          config.secret_key = '#{SecureRandom.hex(64)}'
+      
+      Please ensure you restarted your application after installing Devise or setting the key.
+WARNING
+
     end
   end
 else


### PR DESCRIPTION
@nbudin what do you think about this? 

Should smooth deployment a bit by not requiring Devise’s secret_key to be set
in an initializer in production. DCA should not have a need for the secret.