### PR TITLE
Removed sqlite3-rupy from gemspec

### DIFF
--- a/devise_cas_authenticatable.gemspec
+++ b/devise_cas_authenticatable.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec-rails")
   s.add_development_dependency("mocha")
   s.add_development_dependency("shoulda", "~> 3.4.0")
-  s.add_development_dependency("sqlite3-ruby")
+  s.add_development_dependency("sqlite3")
   s.add_development_dependency("sham_rack")
   s.add_development_dependency("capybara")
   s.add_development_dependency('crypt-isaac')


### PR DESCRIPTION
Replace with "sqlite" See this friendly message from the sqlite team:

Hello! The sqlite3-ruby gem has changed it's name to just sqlite3.  Rather than
installing `sqlite3-ruby`, you should install `sqlite3`.  Please update your
dependencies accordingly.

Thanks from the Ruby sqlite3 team!

<3 <3 <3 <3