### PR TITLE
Configure the Ticket value used to find the User

### DIFF
--- a/lib/devise_cas_authenticatable.rb
+++ b/lib/devise_cas_authenticatable.rb
@@ -69,7 +69,7 @@ module Devise
   
   # The CAS reponse value used to find users in the local database
   # it is required that this field be in cas_extra_attributes
-  @@cas_username_field = :id
+  @@cas_user_identifier = nil
 
   # Name of the parameter passed in the logout query 
   @@cas_destination_logout_param_name = nil
@@ -77,7 +77,7 @@ module Devise
   # Additional options for CAS client object
   @@cas_client_config_options = {}
 
-  mattr_accessor :cas_base_url, :cas_login_url, :cas_logout_url, :cas_validate_url, :cas_destination_url, :cas_follow_url, :cas_logout_url_param, :cas_create_user, :cas_destination_logout_param_name, :cas_username_column, :cas_enable_single_sign_out, :cas_single_sign_out_mapping_strategy, :cas_username_field, :cas_client_config_options
+  mattr_accessor :cas_base_url, :cas_login_url, :cas_logout_url, :cas_validate_url, :cas_destination_url, :cas_follow_url, :cas_logout_url_param, :cas_create_user, :cas_destination_logout_param_name, :cas_username_column, :cas_enable_single_sign_out, :cas_single_sign_out_mapping_strategy, :cas_user_identifier, :cas_client_config_options
 
   def self.cas_create_user?
     cas_create_user

--- a/lib/devise_cas_authenticatable.rb
+++ b/lib/devise_cas_authenticatable.rb
@@ -66,6 +66,10 @@ module Devise
   # The model attribute used for query conditions. Should be the same as
   # the rubycas-server username_column. :username by default
   @@cas_username_column = :username
+  
+  # The CAS reponse value used to find users in the local database
+  # it is required that this field be in cas_extra_attributes
+  @@cas_username_field = :id
 
   # Name of the parameter passed in the logout query 
   @@cas_destination_logout_param_name = nil
@@ -73,7 +77,7 @@ module Devise
   # Additional options for CAS client object
   @@cas_client_config_options = {}
 
-  mattr_accessor :cas_base_url, :cas_login_url, :cas_logout_url, :cas_validate_url, :cas_destination_url, :cas_follow_url, :cas_logout_url_param, :cas_create_user, :cas_destination_logout_param_name, :cas_username_column, :cas_enable_single_sign_out, :cas_single_sign_out_mapping_strategy, :cas_client_config_options
+  mattr_accessor :cas_base_url, :cas_login_url, :cas_logout_url, :cas_validate_url, :cas_destination_url, :cas_follow_url, :cas_logout_url_param, :cas_create_user, :cas_destination_logout_param_name, :cas_username_column, :cas_enable_single_sign_out, :cas_single_sign_out_mapping_strategy, :cas_username_field, :cas_client_config_options
 
   def self.cas_create_user?
     cas_create_user

--- a/lib/devise_cas_authenticatable/model.rb
+++ b/lib/devise_cas_authenticatable/model.rb
@@ -28,9 +28,14 @@ module Devise
               identifier = ticket_response.extra_attributes[::Devise.cas_user_identifier]
             end
 
-            # If cas_user_identifier isn't in extra_attributes, then we're done here
-            return nil if identifier.nil?
+            # If cas_user_identifier isn't in extra_attributes, or the value is blank, then we're done here
+            if identifier.nil?
+              logger.warn("Could not find a value for [#{::Devise.cas_user_identifier}] in cas_extra_attributes so we cannot find the User.")
+              logger.warn("Make sure config.cas_user_identifier is set to a field that appears in cas_extra_attributes")
+              return nil 
+            end
 
+            logger.debug("Using conditions {#{::Devise.cas_username_column} => #{identifier}} to find the User")
             conditions = {::Devise.cas_username_column => identifier} 
             # We don't want to override Devise 1.1's find_for_authentication
             resource = if respond_to?(:find_for_authentication)

--- a/lib/devise_cas_authenticatable/model.rb
+++ b/lib/devise_cas_authenticatable/model.rb
@@ -19,16 +19,19 @@ module Devise
           ::Devise.cas_client.validate_service_ticket(ticket) unless ticket.has_been_validated?
           
           if ticket.is_valid?
-           condition = nil
-           ticket_response = ticket.respond_to?(:user) ? ticket : ticket.response
+            identifier = nil
+            ticket_response = ticket.respond_to?(:user) ? ticket : ticket.response
 
-           if ::Devise.cas_username_field.nil?
-              condition = ticket_response.user
-           else
-              condition = ticket_response.extra_attributes[::Devise.cas_username_field]
-           end
+            if ::Devise.cas_user_identifier.blank?
+              identifier = ticket_response.user
+            else
+              identifier = ticket_response.extra_attributes[::Devise.cas_user_identifier]
+            end
 
-           conditions = {::Devise.cas_username_column => condition} 
+            # If cas_user_identifier isn't in extra_attributes, then we're done here
+            return nil if identifier.nil?
+
+            conditions = {::Devise.cas_username_column => identifier} 
             # We don't want to override Devise 1.1's find_for_authentication
             resource = if respond_to?(:find_for_authentication)
               find_for_authentication(conditions)

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -32,6 +32,9 @@ describe Devise::Models::CasAuthenticatable do
       User.expects(:find).with(:first, {:conditions => {:id => 10}})
 
       User.authenticate_with_cas_ticket(@ticket)
+
+      #Reset this otherwise it'll blow up other specs
+      Devise.cas_user_identifier = nil
     end
 
     it "should authenticate as normal is config.cas_user_identifier is not set" do
@@ -46,6 +49,9 @@ describe Devise::Models::CasAuthenticatable do
       Devise.cas_username_column = :username   
       User.expects(:find).never
       User.authenticate_with_cas_ticket(@ticket).should be_nil 
+
+      #Reset this otherwise it'll blow up other specs
+      Devise.cas_user_identifier = nil
     end
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Devise::Models::CasAuthenticatable do  
+
+  describe "When the user lookup is by something other than username" do
+    before(:each) do
+      @ticket = CASClient::ServiceTicket.new("ST-test", nil)
+      @ticket.extra_attributes = {:id => 10}
+      @ticket.success = true
+      @ticket.user = "testusername"
+
+      Devise.cas_create_user = false
+
+      #
+      # We needed to stub :find_for_authentication to return false
+      # but wanted to allow other respond_to? calls to function
+      # normally 
+      #
+      User.stubs(:respond_to?) do |arg|
+        if arg == :find_for_authentication
+          return false
+        else
+          return User.respond_to? arg
+        end
+      end
+    end
+
+    it "should authenticate using whatever is specified in config.cas_user_identifier" do
+      Devise.cas_user_identifier = :id
+      Devise.cas_username_column = :id
+
+      User.expects(:find).with(:first, {:conditions => {:id => 10}})
+
+      User.authenticate_with_cas_ticket(@ticket)
+    end
+
+    it "should authenticate as normal is config.cas_user_identifier is not set" do
+      Devise.cas_user_identifier = nil
+      Devise.cas_username_column = :username
+      User.expects(:find).with(:first, {:conditions => {:username => @ticket.user}})
+      User.authenticate_with_cas_ticket(@ticket)
+    end
+
+    it "should return nil if cas_user_identifier is not in cas_extra_attributes" do
+      Devise.cas_user_identifier = :unknown_ticket_field
+      Devise.cas_username_column = :username   
+      User.expects(:find).never
+      User.authenticate_with_cas_ticket(@ticket).should be_nil 
+    end
+  end
+end


### PR DESCRIPTION
By default, devise_cas_authenticatable uses "user" from the Ticket to load the User from the database.

Across our apps, our Users are linked by a common id, not by username. This change allows devise_cas_authenticatable to be configured to use a value other than "user" in the Ticket.

The client can set "cas_user_identifier" to a field that appears in cas_extra_attributes. devise_cas_authenticatable will use this value when finding the user.

Happy to discuss if you have comments or you think we should attack this another way.