### PR TITLE
possibility to use Rails routes for Devise.cas_action_url

### DIFF
--- a/lib/devise_cas_authenticatable.rb
+++ b/lib/devise_cas_authenticatable.rb
@@ -7,6 +7,8 @@ require 'devise_cas_authenticatable/exceptions'
 
 require 'devise_cas_authenticatable/single_sign_out'
 
+require 'devise_cas_authenticatable/cas_action_url_factory_base'
+
 require 'rubycas-client'
 
 require 'devise_cas_authenticatable/railtie' if defined?(Rails::Railtie)
@@ -111,24 +113,11 @@ module Devise
   
   private
   def self.cas_action_url(base_url, mapping, action)
-    u = URI.parse(base_url)
-    u.query = nil
-    u.path = if mapping.respond_to?(:fullpath)
-      if ENV['RAILS_RELATIVE_URL_ROOT']
-        ENV['RAILS_RELATIVE_URL_ROOT'] + mapping.fullpath
-      else
-        mapping.fullpath
-      end
-    else
-      if ENV['RAILS_RELATIVE_URL_ROOT']
-        ENV['RAILS_RELATIVE_URL_ROOT'] + mapping.raw_path
-      else
-        mapping.raw_path
-      end
-    end
-    u.path << "/" unless u.path =~ /\/$/
-    u.path << action
-    u.to_s
+    cas_action_url_factory_class.new(base_url, mapping, action).call
+  end
+
+  def self.cas_action_url_factory_class
+    @cas_action_url_factory_class ||= CasActionUrlFactoryBase.prepare_class
   end
 end
 

--- a/lib/devise_cas_authenticatable/cas_action_url_factory_base.rb
+++ b/lib/devise_cas_authenticatable/cas_action_url_factory_base.rb
@@ -1,0 +1,65 @@
+module Devise
+  class CasActionUrlFactoryBase
+    attr_reader :base_url, :mapping, :action
+
+    def self.prepare_class
+      Class.new(self) do
+        include Rails.application.routes.url_helpers
+        include Rails.application.routes.mounted_helpers if Rails.application.routes.try(:mounted_helpers)
+      end
+    end
+
+    def initialize(base_url, mapping, action)
+      @base_url = base_url
+      @mapping  = mapping
+      @action   = action
+    end
+
+    def call
+      uri      = URI.parse(base_url).tap { |uri| uri.query = nil }
+      uri.path = load_base_path
+      uri.to_s
+    end
+
+    alias_method :build, :call
+
+    private
+    def load_base_path
+      load_routes_path || load_mapping_path
+    end
+
+    def load_routes_path
+      router_name = mapping.router_name || Devise.available_router_name
+      context     = send(router_name)
+
+      route = "#{mapping.singular}_#{action}_path"
+      if context.respond_to? route
+        context.send route
+      else
+        nil
+      end
+    rescue NameError, NoMethodError
+      nil
+    end
+
+    def load_mapping_path
+      path = mapping_fullpath || mapping_raw_path
+      path << "/" unless path =~ /\/$/
+      path << action
+      path
+    end
+
+    def mapping_fullpath
+      return nil unless mapping.respond_to?(:fullpath)
+      "#{rails_relative_url_root}#{mapping.fullpath}"
+    end
+
+    def mapping_raw_path
+      "#{rails_relative_url_root}#{mapping.raw_path}"
+    end
+
+    def rails_relative_url_root
+      ENV['RAILS_RELATIVE_URL_ROOT']
+    end
+  end
+end


### PR DESCRIPTION
refactoring `Devise.cas_action_url` method into a class.

The first time it's needed it will create a new class with
Rails routes helpers included (also engines).

It will try to use the routes if it can, looking it up in a similar way that Devise does.

This allow to use devise_cas_authenticatable with a Devise inside of an engine.