### PR TITLE
Fix Single Sign Out using RedisSessionStore

### DIFF
--- a/lib/devise_cas_authenticatable/single_sign_out.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out.rb
@@ -46,6 +46,9 @@ module DeviseCasAuthenticatable
         elsif session_store_class.name =~ /ActionDispatch::Session::DalliStore/
           current_session_store.send(:destroy_session, env, sid, drop: true)
           true
+        elsif session_store_class.name =~ /RedisSessionStore/
+          current_session_store.send(:destroy_session_from_sid, sid)
+          true
         elsif session_store_class.name =~ /Redis/
           current_session_store.instance_variable_get(:@pool).del(sid)
           true

--- a/lib/devise_cas_authenticatable/single_sign_out.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out.rb
@@ -47,7 +47,7 @@ module DeviseCasAuthenticatable
           current_session_store.send(:destroy_session, env, sid, drop: true)
           true
         elsif session_store_class.name =~ /RedisSessionStore/
-          current_session_store.send(:destroy_session_from_sid, sid)
+          current_session_store.send(:destroy_session, env, sid, drop: true)
           true
         elsif session_store_class.name =~ /Redis/
           current_session_store.instance_variable_get(:@pool).del(sid)


### PR DESCRIPTION
This fixes #101.
It also takes `:key_prefix` into account.