### PR TITLE
Loop through middleware (including checking @target instance variable…

### DIFF
--- a/lib/devise_cas_authenticatable/single_sign_out.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out.rb
@@ -27,7 +27,7 @@ module DeviseCasAuthenticatable
       def current_session_store
         app = Rails.application.app
         begin
-          app = (app.instance_variable_get(:@backend) || app.instance_variable_get(:@app))
+          app = (app.instance_variable_get(:@backend) || app.instance_variable_get(:@app) || app.instance_variable_get(:@target))
         end until app.nil? or app.class == session_store_class
         app
       end


### PR DESCRIPTION
…) to find the session store.

New Relic wraps the middleware with MiddlewareProxy.  It uses the `@target` instance variable to access the wrapped `@app` instance variable.  If NewRelic is in the stack, `current_session_store` could return `nil`.  

See [middleware_proxy.rb](https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/middleware_proxy.rb#L60-L71) from NewRelic.  
