### PR TITLE
add Rails namespace to logger call

### DIFF
--- a/lib/devise_cas_authenticatable/routes.rb
+++ b/lib/devise_cas_authenticatable/routes.rb
@@ -21,7 +21,7 @@ if defined? ActionDispatch::Routing
 
     def raise_no_secret_key #:nodoc:
       # Devise_cas_authenticatable does not store passwords, so does not need a secret!
-      logger.warn <<-WARNING
+      Rails.logger.warn <<-WARNING
       Devise_cas_authenticatable has suppressed an exception from being raised for missing Devise.secret_key.
       If devise_cas_authenticatable is the only devise module you are using for authentication you can safely ignore this warning.
       However, if you use another module that requires the secret_key please follow these instructions from Devise:


### PR DESCRIPTION
if devise_cas_authenticatable is an engine dependency used by an api-only wbappapp (i.e. no need of secret_key) happens that logger is undefined

````
/Users/mario/.rvm/gems/ruby-2.2.3@support/gems/devise_cas_authenticatable-1.7.0/lib/devise_cas_authenticatable/routes.rb:24:in `raise_no_secret_key': undefined local variable or method `logger' for #<ActionDispatch::Routing::Mapper:0x007fde1c2af5b0> (NameError)
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/devise-3.5.3/lib/devise/rails/routes.rb:223:in `devise_for'
  from /Volumes/storage/dev/application/api_engine_commons/config/routes.rb:3:in `block in <top (required)>'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/actionpack-4.2.0/lib/action_dispatch/routing/mapper.rb:601:in `instance_exec'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/actionpack-4.2.0/lib/action_dispatch/routing/mapper.rb:601:in `block in with_default_scope'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/actionpack-4.2.0/lib/action_dispatch/routing/mapper.rb:816:in `scope'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/actionpack-4.2.0/lib/action_dispatch/routing/mapper.rb:600:in `with_default_scope'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/actionpack-4.2.0/lib/action_dispatch/routing/route_set.rb:421:in `eval_block'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/actionpack-4.2.0/lib/action_dispatch/routing/route_set.rb:401:in `draw'
  from /Volumes/storage/dev/application/api_engine_commons/config/routes.rb:1:in `<top (required)>'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:268:in `load'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:268:in `block in load'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:240:in `load_dependency'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:268:in `load'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/application/routes_reloader.rb:40:in `block in load_paths'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/application/routes_reloader.rb:40:in `each'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/application/routes_reloader.rb:40:in `load_paths'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/application/routes_reloader.rb:16:in `reload!'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/application.rb:169:in `reload_routes!'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/devise-3.5.3/lib/devise/rails.rb:14:in `block in <class:Engine>'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:36:in `call'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:45:in `block in run_load_hooks'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:44:in `each'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:44:in `run_load_hooks'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/application/finisher.rb:55:in `block in <module:Finisher>'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/initializable.rb:30:in `instance_exec'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/initializable.rb:30:in `run'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/initializable.rb:55:in `block in run_initializers'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:226:in `block in tsort_each'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:429:in `each_strongly_connected_component_from'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:347:in `block in each_strongly_connected_component'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:345:in `each'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:345:in `call'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:345:in `each_strongly_connected_component'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:224:in `tsort_each'
  from /Users/mario/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/tsort.rb:203:in `tsort_each'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/initializable.rb:54:in `run_initializers'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/application.rb:352:in `initialize!'
  from /Volumes/storage/dev/application/support/config/environment.rb:5:in `<top (required)>'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274:in `require'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274:in `block in require'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:240:in `load_dependency'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274:in `require'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/application.rb:328:in `require_environment!'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/commands/commands_tasks.rb:142:in `require_application_and_environment!'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/commands/commands_tasks.rb:67:in `console'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
  from /Users/mario/.rvm/gems/ruby-2.2.3@support/gems/railties-4.2.0/lib/rails/commands.rb:17:in `<top (required)>'
  from bin/rails:8:in `require'
  from bin/rails:8:in `<main>'
````