### PR TITLE
Redis SLO strategy

### DIFF
--- a/lib/devise_cas_authenticatable/single_sign_out.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out.rb
@@ -56,4 +56,5 @@ end
 require 'devise_cas_authenticatable/single_sign_out/strategies'
 require 'devise_cas_authenticatable/single_sign_out/strategies/base'
 require 'devise_cas_authenticatable/single_sign_out/strategies/rails_cache'
+require 'devise_cas_authenticatable/single_sign_out/strategies/redis_cache'
 require 'devise_cas_authenticatable/single_sign_out/rack'

--- a/lib/devise_cas_authenticatable/single_sign_out/strategies/redis_cache.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out/strategies/redis_cache.rb
@@ -2,8 +2,8 @@ module DeviseCasAuthenticatable
   module SingleSignOut
     module Strategies
       class RedisCache < Base
-        include DeviseCasAuthenticatable::SingleSignOut::DestroySession
-current_session_store.inst
+        include ::DeviseCasAuthenticatable::SingleSignOut::DestroySession
+
         def store_session_id_for_index(session_index, session_id)
           logger.debug("Storing #{session_id} for index #{session_index}")
           current_session_store.instance_variable_get(:@pool).set(

--- a/lib/devise_cas_authenticatable/single_sign_out/strategies/redis_cache.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out/strategies/redis_cache.rb
@@ -1,20 +1,26 @@
 module DeviseCasAuthenticatable
   module SingleSignOut
     module Strategies
-      class RailsCache < Base
+      class RedisCache < Base
+        include DeviseCasAuthenticatable::SingleSignOut::DestroySession
+current_session_store.inst
         def store_session_id_for_index(session_index, session_id)
           logger.debug("Storing #{session_id} for index #{session_index}")
-          Rails.cache.write(cache_key(session_index), session_id)
+          current_session_store.instance_variable_get(:@pool).set(
+            cache_key(session_index),
+            session_id
+          )
         end
         def find_session_id_by_index(session_index)
-          sid = Rails.cache.read(cache_key(session_index))
+          sid = current_session_store.instance_variable_get(:@pool).get(cache_key(session_index))
           logger.debug("Found session id #{sid} for index #{session_index}")
           sid
         end
         def delete_session_index(session_index)
           logger.debug("Deleting index #{session_index}")
-          Rails.cache.delete(cache_key(session_index))
+          destroy_session_by_id(session_index)
         end
+
         private
         def cache_key(session_index)
           "devise_cas_authenticatable:#{session_index}"
@@ -24,4 +30,4 @@ module DeviseCasAuthenticatable
   end
 end
 
-::DeviseCasAuthenticatable::SingleSignOut::Strategies.add(:rails_cache, DeviseCasAuthenticatable::SingleSignOut::Strategies::RailsCache )
+::DeviseCasAuthenticatable::SingleSignOut::Strategies.add(:redis_cache, DeviseCasAuthenticatable::SingleSignOut::Strategies::RedisCache )


### PR DESCRIPTION
This strategy enables your app to look up the redis-session associated with the CAS ticket anytime a user gets signed out of the CAS so it can be invalidated.
