### PR TITLE
Fix for Rails 5 deprecation message when using middleware

### DIFF
--- a/lib/devise_cas_authenticatable/railtie.rb
+++ b/lib/devise_cas_authenticatable/railtie.rb
@@ -4,7 +4,11 @@ require 'rails'
 module DeviseCasAuthenticatable
   class Railtie < ::Rails::Railtie
     initializer "devise_cas_authenticatable.use_rack_middleware" do |app|
-      app.config.middleware.use "DeviseCasAuthenticatable::SingleSignOut::StoreSessionId"
+      if Rails::VERSION::MAJOR < 5
+        app.config.middleware.use "DeviseCasAuthenticatable::SingleSignOut::StoreSessionId"
+      else
+        app.config.middleware.use DeviseCasAuthenticatable::SingleSignOut::StoreSessionId
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 5 introduced a change that deprecates the use of strings or symbols when defining the class to use for middleware https://github.com/rails/rails/commit/83b767ce. This commit should fix this and make it backwards compatible