### PR TITLE
Skipped callbacks don't raise exception

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -5,7 +5,7 @@ class Devise::CasSessionsController < Devise::SessionsController
     unloadable
   end
 
-  skip_before_filter :verify_authenticity_token, :only => [:single_sign_out]
+  skip_before_filter :verify_authenticity_token, :only => [:single_sign_out], :raise => false
 
   def new
     if memcache_checker.session_store_memcache? && !memcache_checker.alive?


### PR DESCRIPTION
Since Rails 5, skipped unrecognized callbacks raise ArgumentError:
https://github.com/rails/rails/blob/v5.0.0.beta1/activesupport/CHANGELOG.md