### PR TITLE
Update skip filter

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -5,7 +5,11 @@ class Devise::CasSessionsController < Devise::SessionsController
     unloadable
   end
 
-  skip_before_action :verify_authenticity_token, :only => [:single_sign_out], :raise => false
+  if Rails.version =~ /^5/
+    skip_before_action :verify_authenticity_token, :only => [:single_sign_out], :raise => false
+  else
+    skip_before_filter :verify_authenticity_token, :only => [:single_sign_out], :raise => false
+  end
 
   def new
     if memcache_checker.session_store_memcache? && !memcache_checker.alive?

--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -5,7 +5,7 @@ class Devise::CasSessionsController < Devise::SessionsController
     unloadable
   end
 
-  skip_before_filter :verify_authenticity_token, :only => [:single_sign_out], :raise => false
+  skip_before_action :verify_authenticity_token, :only => [:single_sign_out], :raise => false
 
   def new
     if memcache_checker.session_store_memcache? && !memcache_checker.alive?


### PR DESCRIPTION
- Update syntax to keep compatible with rails 5(+):

`WARNING: skip_before_filter is deprecated and will be removed in Rails
5.1. Use skip_before_action instead.`
