### PR TITLE
Fix for 'Unable to autoload constant Devise::CasSessionsController' in Rails 5

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -1,7 +1,7 @@
 class Devise::CasSessionsController < Devise::SessionsController
   include DeviseCasAuthenticatable::SingleSignOut::DestroySession
 
-  unless Rails.version =~/^4/
+  if Rails::VERSION::MAJOR < 4
     unloadable
   end
 


### PR DESCRIPTION
The regexp for making the controller unloadable was only working for Rails 4 so should be a bit more flexible now, should fix #134 