### PR TITLE
Rails 5.1 fix (render :nothing is deprecated)

### DIFF
--- a/app/controllers/devise/cas_sessions_controller.rb
+++ b/app/controllers/devise/cas_sessions_controller.rb
@@ -52,7 +52,7 @@ class Devise::CasSessionsController < Devise::SessionsController
       logger.warn "Ignoring CAS single-sign-out request as feature is not currently enabled."
     end
 
-    render :nothing => true
+    head :ok
   end
 
   private


### PR DESCRIPTION
`render :nothing` is deprecated in Rails 5.1, which causes this action to fail with MissingTemplate.

`head :ok` has been supported for a long time and is preferred syntax.