### PR TITLE
Fix Redis session storage

### DIFF
--- a/lib/devise_cas_authenticatable/single_sign_out/with_conn.rb
+++ b/lib/devise_cas_authenticatable/single_sign_out/with_conn.rb
@@ -1,0 +1,14 @@
+module DeviseCasAuthenticatable
+  module SingleSignOut
+    module WithConn
+      def with_conn(&block)
+        if old_style_conn = current_session_store.instance_variable_get(:@pool)
+          yield old_style_conn
+        else
+          current_session_store.instance_variable_get(:@conn)
+            .instance_variable_get(:@pool).with &block
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Current connection_pool (2.2.2) uses a #with block to expose connection.
Also, currently @pool resides inside of @conn.

I tried to preserve the old way as well, but I have no way of testing it.