### PR TITLE
Redirect to RackCAS/FakeCAS when server_url is nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ config.rack_cas.server_url = "https://cas.myorganization.com" # replace with you
 config.rack_cas.service = "/users/service" # If your user model isn't called User, change this
 ```
 
+Rack-cas comes with a fake CAS server that it enables by default in the Rails test environment. This will log in any
+username and password combination you use, and more information can be found in the
+[rack-cas README](https://github.com/biola/rack-cas). If you want to enable Fake CAS in development as well, add this
+to your Rails development config:
+
+```ruby
+config.rack_cas.fake = true
+```
+
 Finally, you may need to add some configuration to your config/initializers/devise.rb in order
 to tell your app how to talk to your CAS server.  This isn't always required.  Here's an example:
 

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -18,10 +18,6 @@ describe Devise::Strategies::CasAuthenticatable, :type => 'acceptance' do
     page.driver.submit :delete, destroy_user_session_url, {}
   end
 
-  def cas_logout_url
-    @cas_logout_url ||= Devise.cas_base_url + '/logout?service'
-  end
-
   def sign_into_cas(username, password)
     visit '/users/sign_in'
     fill_in 'username', with: username


### PR DESCRIPTION
RackCAS's Fake CAS is automatically included by RackCAS in the Rails test environment and comes with a hardcoded /logout route. This change redirects to /logout when server_url is not set and logs a warning if Rails is not in test. I've chosen to log that warning even when Fake CAS is included outside test so there may an argument for testing for FakeCAS before logging the warning.

Also added a note to the README about FakeCAS.